### PR TITLE
fix cli queue throwing undefined method queue

### DIFF
--- a/src/event/queue.php
+++ b/src/event/queue.php
@@ -24,7 +24,6 @@ return function($cwd, $args) {
     //now queue
     $this
         ->package('global')
-        ->service('queue-main')
         ->queue($args[3], $data);
 
     CLI::success('`'.$args[3].'` has been successfully queued.');


### PR DESCRIPTION
Fix the issue when executing queue command from cradle cli:

vendor/bin/cradle package cblanquera/cradle-queue queue get-repository-branch

PHP Fatal error:  Call to undefined method PhpAmqpLib\Connection\AMQPLazyConnection::queue() in /server/public/php/timetracker/vendor/cblanquera/cradle-queue/src/event/queue.php on line 28

Fatal error: Call to undefined method PhpAmqpLib\Connection\AMQPLazyConnection::queue() in /server/public/php/timetracker/vendor/cblanquera/cradle-queue/src/event/queue.php on line 28
